### PR TITLE
Trust Metric v0: participation-weighted score with miss/slash penalties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 venv/
+minimalApproach/code/.env

--- a/minimalApproach/code/__init__.py
+++ b/minimalApproach/code/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["config", "http", "beaconchain", "collectors", "features", "storage"]

--- a/minimalApproach/code/beaconchain.py
+++ b/minimalApproach/code/beaconchain.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from typing import Dict, Any
+from .http import HttpClient
+
+# Beaconcha.in /api/v1 endpoints relevant for validator collection
+
+def get_validator_overview(client: HttpClient, index: int) -> Dict[str, Any]:
+    data = client.get_json(f"validator/{index}")
+    d = data.get("data", {}) if isinstance(data, dict) else {}
+    return {
+        "validator_index": index,
+        "pubkey": d.get("pubkey"),
+        "status": d.get("status"),
+        "effective_balance_gwei": d.get("effectivebalance"),
+        "slashed": d.get("slashed"),
+        "activation_epoch": d.get("activationepoch"),
+        "exit_epoch": d.get("exitepoch"),
+        "withdrawal_credentials": d.get("withdrawalcredentials"),
+    }
+
+def get_validator_performance(client: HttpClient, index: int) -> Dict[str, Any]:
+    out = {"validator_index": index}
+    perf = client.get_json(f"validator/{index}/performance")
+    p = perf.get("data", {}) if isinstance(perf, dict) else {}
+    if isinstance(p, list):
+        p = p[0] if p else {}
+    out.update({
+        "attestations_total": p.get("attestationscount"),
+        "att_missed_total": p.get("missedattestations"),
+        "proposals_total": p.get("proposalscount"),
+        "prop_missed_total": p.get("missedproposals"),
+        "inclusion_delay_avg": p.get("inclusiondelay"),
+        "rewards_sum_gwei": p.get("sumrewards"),
+    })
+    return out

--- a/minimalApproach/code/cli.py
+++ b/minimalApproach/code/cli.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+import argparse
+import sys
+
+from eth_dataset.config import (
+    get_api_base,
+    get_api_key,
+    get_api_key_transport,
+    get_rate_limit_seconds,
+    get_timeout_seconds,
+    get_out_dir,
+)
+from eth_dataset.http import HttpClient
+from eth_dataset.collectors.validators import load_validators_from_args
+from eth_dataset.collectors.performance import collect_validator_rows
+from eth_dataset.features.trust import compute_trust_v0
+from eth_dataset.storage.io import write_outputs
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="ETH-only dataset collector (Beaconcha.in /api/v1)")
+    ap.add_argument("--validators", help="Comma-separated validator indexes")
+    ap.add_argument("--validators-file", help="File with one validator index per line")
+    ap.add_argument("--api-base", default=None, help="Override API base (default: env/API_BASE)")
+    ap.add_argument("--api-key", default=None, help="Beaconcha.in API key (env: BEACONCHAIN_API_KEY)")
+    ap.add_argument("--key-transport", choices=["header", "query"], default=None,
+                    help="Send key in header or query (default: env/API_KEY_TRANSPORT or header)")
+    ap.add_argument("--sleep", type=float, default=None, help="Delay between calls (default ~6.2s)")
+    ap.add_argument("--timeout", type=int, default=None, help="HTTP timeout seconds (default 30)")
+    ap.add_argument("--out-dir", default=None, help="Output dir (default: data/eth2/mainnet)")
+    ap.add_argument("--out-prefix", default="validators_mvp", help="Output filename prefix")
+    return ap.parse_args()
+
+def main() -> None:
+    args = parse_args()
+
+    base = args.api_base or get_api_base()
+    key  = args.api_key or get_api_key()
+    transport = args.key_transport or get_api_key_transport()
+    sleep = args.sleep if args.sleep is not None else get_rate_limit_seconds()
+    timeout = args.timeout if args.timeout is not None else get_timeout_seconds()
+
+    client = HttpClient(
+        base_url=base,
+        api_key=key,
+        api_key_transport=transport,
+        rate_limit_seconds=sleep,
+        timeout_seconds=timeout,
+    )
+    # Always use 'eth_dataset/data/ethereum' as output directory
+    out_dir = get_out_dir('eth_dataset/data/ethereum')
+
+    indexes = load_validators_from_args(args.validators, args.validators_file)
+    if not indexes:
+        print("[ERROR] No validator indexes provided. Use --validators or --validators-file.", file=sys.stderr)
+        sys.exit(2)
+
+    rows = collect_validator_rows(client, indexes)
+    for r in rows:
+        r["trust_v0"] = compute_trust_v0(r)
+
+    write_outputs(rows, out_dir, prefix=args.out_prefix)
+    print(f"[OK] Wrote outputs to {out_dir}")
+
+if __name__ == "__main__":
+    main()

--- a/minimalApproach/code/collectors/__init__.py
+++ b/minimalApproach/code/collectors/__init__.py
@@ -1,0 +1,1 @@
+# namespace package

--- a/minimalApproach/code/collectors/performance.py
+++ b/minimalApproach/code/collectors/performance.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+from typing import Dict, Any, List
+from ..beaconchain import get_validator_overview, get_validator_performance
+from ..http import HttpClient
+
+def collect_validator_rows(client: HttpClient, indexes: List[int]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for idx in indexes:
+        ov = get_validator_overview(client, idx)
+        pf = get_validator_performance(client, idx)
+        rows.append({**ov, **pf})
+    return rows

--- a/minimalApproach/code/collectors/validators.py
+++ b/minimalApproach/code/collectors/validators.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from typing import List
+
+def load_validators_from_args(arg_str: str | None, file_path: str | None) -> List[int]:
+    vals: List[int] = []
+    if arg_str:
+        for tok in arg_str.split(","):
+            tok = tok.strip()
+            if not tok:
+                continue
+            try:
+                vals.append(int(tok))
+            except ValueError:
+                pass
+    if file_path:
+        from pathlib import Path
+        p = Path(file_path)
+        if p.exists():
+            for line in p.read_text().splitlines():
+                s = line.strip()
+                if not s:
+                    continue
+                try:
+                    vals.append(int(s))
+                except ValueError:
+                    pass
+    # de-duplicate preserving order
+    seen, uniq = set(), []
+    for v in vals:
+        if v not in seen:
+            uniq.append(v); seen.add(v)
+    return uniq

--- a/minimalApproach/code/config.py
+++ b/minimalApproach/code/config.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import Optional
+
+# Optional: load .env if python-dotenv is installed
+try:
+    from dotenv import load_dotenv, find_dotenv  # type: ignore
+    # Try to locate a .env up the tree; fall back to repo root/".env"
+    loaded = load_dotenv(find_dotenv())
+    if not loaded:
+        repo_root = Path(__file__).resolve().parents[1]  # folder containing eth_dataset/
+        load_dotenv(repo_root / ".env")
+except Exception:
+    pass
+
+API_BASE_DEFAULT = "https://beaconcha.in/api/v1"
+RATE_LIMIT_SECONDS_DEFAULT = 6.2   # ~10 req/min free tier
+TIMEOUT_SECONDS_DEFAULT = 30
+DEFAULT_OUT_DIR = Path("data/eth2/mainnet")
+
+def get_api_base() -> str:
+    return os.getenv("API_BASE", API_BASE_DEFAULT)
+
+def get_api_key() -> Optional[str]:
+    return os.getenv("BEACONCHAIN_API_KEY")
+
+def get_api_key_transport() -> str:
+    """
+    'header' -> send as header: apikey: <KEY>
+    'query'  -> send as query:  ?apikey=<KEY>
+    """
+    v = os.getenv("API_KEY_TRANSPORT", "header").strip().lower()
+    return v if v in ("header", "query") else "header"
+
+def get_rate_limit_seconds() -> float:
+    try:
+        return float(os.getenv("RATE_LIMIT_SECONDS", RATE_LIMIT_SECONDS_DEFAULT))
+    except Exception:
+        return RATE_LIMIT_SECONDS_DEFAULT
+
+def get_timeout_seconds() -> int:
+    try:
+        return int(os.getenv("HTTP_TIMEOUT_SECONDS", TIMEOUT_SECONDS_DEFAULT))
+    except Exception:
+        return TIMEOUT_SECONDS_DEFAULT
+
+def get_out_dir(overridden: Optional[str] = None) -> Path:
+    p = Path(overridden) if overridden else DEFAULT_OUT_DIR
+    p.mkdir(parents=True, exist_ok=True)
+    return p

--- a/minimalApproach/code/features/__init__.py
+++ b/minimalApproach/code/features/__init__.py
@@ -1,0 +1,1 @@
+# namespace package

--- a/minimalApproach/code/features/trust.py
+++ b/minimalApproach/code/features/trust.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import Dict, Any
+
+def compute_trust_v0(row: Dict[str, Any]) -> float:
+    """
+    trust_v0 = 0.6*participation - 0.35*miss_rate - 0.05*slashed_flag
+    """
+    att_total = row.get("attestations_total") or 0
+    miss_att = row.get("att_missed_total") or 0
+    denom = att_total + miss_att
+    participation = (att_total / denom) if denom > 0 else 0.0
+    miss_rate = (miss_att / denom) if denom > 0 else 0.0
+    slashed = 1 if row.get("slashed") else 0
+    trust = 0.6 * participation - 0.35 * miss_rate - 0.05 * slashed
+    return round(float(trust), 4)

--- a/minimalApproach/code/http.py
+++ b/minimalApproach/code/http.py
@@ -1,0 +1,38 @@
+# Copied from http.py to resolve naming conflict
+import requests
+from typing import Any, Dict, Optional
+
+class HttpClient:
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        api_key_transport: str,
+        rate_limit_seconds: float,
+        timeout_seconds: int,
+    ):
+        self.base_url = base_url
+        self.api_key = api_key
+        self.api_key_transport = api_key_transport
+        self.rate_limit_seconds = rate_limit_seconds
+        self.timeout_seconds = timeout_seconds
+
+    def _build_url(self, path: str) -> str:
+        return f"{self.base_url.rstrip('/')}/{path.lstrip('/')}"
+
+    def _inject_key(self, params: Optional[Dict[str, Any]], headers: Dict[str, str]) -> Dict[str, Any]:
+        if self.api_key_transport == "header":
+            headers["X-API-KEY"] = self.api_key
+        elif self.api_key_transport == "query":
+            if params is None:
+                params = {}
+            params["apikey"] = self.api_key
+        return params or {}
+
+    def get_json(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        headers = {}
+        params = self._inject_key(params, headers)
+        url = self._build_url(path)
+        response = requests.get(url, params=params, headers=headers, timeout=self.timeout_seconds)
+        response.raise_for_status()
+        return response.json()

--- a/minimalApproach/code/requirements.txt
+++ b/minimalApproach/code/requirements.txt
@@ -1,0 +1,4 @@
+requests>=2.31
+pandas>=2.2
+pyarrow>=15
+python-dotenv>=1.0

--- a/minimalApproach/code/test.py
+++ b/minimalApproach/code/test.py
@@ -1,0 +1,78 @@
+import unittest
+from eth_dataset.config import get_api_base, get_api_key, get_api_key_transport, get_rate_limit_seconds, get_timeout_seconds, get_out_dir
+from eth_dataset.http_client import HttpClient
+from eth_dataset.beaconchain import get_validator_overview, get_validator_performance
+from eth_dataset.collectors.performance import collect_validator_rows
+from eth_dataset.collectors.validators import load_validators_from_args
+from eth_dataset.storage.io import write_outputs
+from pathlib import Path
+import os
+
+class TestConfig(unittest.TestCase):
+    def test_get_api_base(self):
+        self.assertIsInstance(get_api_base(), str)
+
+    def test_get_api_key(self):
+        # Can be None if not set
+        key = get_api_key()
+        self.assertTrue(key is None or isinstance(key, str))
+
+    def test_get_api_key_transport(self):
+        self.assertIsInstance(get_api_key_transport(), str)
+
+    def test_get_rate_limit_seconds(self):
+        self.assertIsInstance(get_rate_limit_seconds(), float)
+
+    def test_get_timeout_seconds(self):
+        self.assertIsInstance(get_timeout_seconds(), int)
+
+    def test_get_out_dir(self):
+        self.assertIsInstance(get_out_dir(), Path)
+
+class TestHttpClient(unittest.TestCase):
+    def test_init(self):
+        client = HttpClient("https://example.com", "dummy_key", "header", 1.0, 10)
+        self.assertIsInstance(client, HttpClient)
+
+class TestBeaconchain(unittest.TestCase):
+    def setUp(self):
+        self.client = HttpClient("https://example.com", "dummy_key", "header", 1.0, 10)
+
+    def test_get_validator_overview(self):
+        # Should handle error gracefully (mocked)
+        try:
+            get_validator_overview(self.client, 0)
+        except Exception:
+            pass
+
+    def test_get_validator_performance(self):
+        try:
+            get_validator_performance(self.client, 0)
+        except Exception:
+            pass
+
+class TestCollectors(unittest.TestCase):
+    def setUp(self):
+        self.client = HttpClient("https://example.com", "dummy_key", "header", 1.0, 10)
+
+    def test_collect_validator_rows(self):
+        try:
+            collect_validator_rows(self.client, [0, 1])
+        except Exception:
+            pass
+
+    def test_load_validators_from_args(self):
+        result = load_validators_from_args("1,2,3", None)
+        self.assertIsInstance(result, list)
+
+class TestStorage(unittest.TestCase):
+    def test_write_outputs(self):
+        rows = [{"a": 1}]
+        out_dir = Path("./test_out")
+        try:
+            write_outputs(rows, out_dir, "test")
+        except Exception:
+            pass
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Introduces a first-pass trust score for validators that favors attestation participation, penalizes missed attestations, and applies a small penalty if slashed. The function is lightweight and rounds outputs to 4 decimals.&#x20;

## Changes

* Add `compute_trust_v0(row: Dict[str, Any]) -> float` in `trust.py`.
* Reads `attestations_total`, `att_missed_total`, and `slashed` from a row dict; computes participation and miss rate with safe zero-denominator handling.

## Logic & Formula

* `trust_v0 = 0.6*participation - 0.35*miss_rate - 0.05*slashed_flag`.
* `participation = att_total / (att_total + miss_att)`; `miss_rate = miss_att / (att_total + miss_att)`; `slashed_flag ∈ {0,1}` based on `slashed`.
* Result is `round(trust, 4)` for stable downstream comparisons

## Edge Cases & Defaults

* If totals are missing or zero, participation and miss\_rate fall back to `0.0`; overall score becomes `0.0` (or `-0.05` if slashed).
* Robust to absent keys via `.get(...)` with sensible defaults.

## Minor

* Type hints added for clarity and editor support.&#x20;
