### PR TITLE
ETH2 Collector MVP — CLI, Trust Score, CSV export - Daily log

### DIFF
--- a/daily-logs/week3/20-08-25.md
+++ b/daily-logs/week3/20-08-25.md
@@ -1,0 +1,52 @@
+### Date & Topic
+
+- **Date:** 20th August, 2025 
+- **Main Focus:** Refactoring the common/ module for robustness and researching the most effective approach to collect Ethereum (ETH2) data for ***Hybrid Dataset Construction for AI-Driven Validator Selection in Proof-of-Stake Blockchain Networks***
+---
+
+### 1. Search
+
+- **What did you look for?**  
+  - Best practices for building reliable HTTP and storage layers in blockchain data pipelines.
+  - Free and paid providers offering Ethereum Beacon REST API access.
+  - Common failure points in authentication and rate-limiting with Beacon endpoints.
+
+- **Where did you search?**  
+  - Ethereum Beacon chain API documentation.
+  - GitHub projects focused on validator/attestation data extraction.
+
+
+
+- **Useful sources found:**  
+  - Code snippets in GitHub repos highlighting how headers are passed in beacon API calls.
+
+   
+
+---
+
+### 2. Investigate
+
+- **What did you dig into?**  
+  - Refactored common/ (http, storage, schemas, provenance) to handle retries, partitioned data, and provenance tracking.
+  - Explored few node providers (QuickNode and Chainstack) as providers; could not come to a conclusion as most of the providers are not, trying to figure out alternative approaches.
+
+- **Any patterns or surprises?**  
+  - none
+   
+---
+
+### 3. Reflect
+
+- **What did you learn?**  
+  - A hardened common/ layer ensures stable data handling across collectors
+- **What’s next?**  
+  - Run first end-to-end pipeline test for Ethereum block and validator data.
+  
+
+---
+
+### 4. Actions
+
+- **Immediate actions:**  
+  - Finalize provider integration
+  

--- a/daily-logs/week3/22-08-25.md
+++ b/daily-logs/week3/22-08-25.md
@@ -1,0 +1,46 @@
+### Date & Topic
+
+- **Date:** 22nd August, 2025 
+- **Main Focus:** Built a minimal ETH2 data collection pipeline (MVP) and produced the first validators dump for ***Hybrid Dataset Construction for AI-Driven Validator Selection in Proof-of-Stake Blockchain Networks***
+---
+
+### 1. Search
+
+- **What did you look for?**  
+  - Beacon REST endpoints/fields for validator overview & performance
+  - Patterns for simple CLI design, API key headers, and basic rate limiting
+
+- **Where did you search?**  
+  - Ethereum Beacon chain API documentation.
+  - Minimal collector examples on GitHub
+
+
+---
+
+### 2. Investigate
+
+- **What did you dig into?**  
+  - - Implemented modules: lightweight HTTP client + env-driven config, CLI wrapper, collectors (overview + performance merge), trust metric v0, and storage I/O 
+  - Added order-preserving index loader and safe parsing for validator lists
+  - Ran end-to-end: fetched validator rows, computed trust score, and got the data validators_mvp.csv
+  - Verified basic field integrity and handled timeouts/missing keys gracefully.
+
+- **Any patterns or surprises?**  
+  - none
+   
+---
+
+### 3. Reflect
+
+- **What did you learn?**  
+  - minimal pipeline is stable enough for small batches and quick iterations
+- **What’s next?**  
+  - prepare a daily run
+  
+
+---
+
+### 4. Actions
+
+- **Immediate actions:**  
+  - Will start gathering data more on eth   


### PR DESCRIPTION
Adds a minimal ETH2 data collector: a CLI that pulls validator overview + performance, computes a simple trust score, and writes CSV/Parquet outputs. Brings in a lightweight HTTP client with API-key headers, env-based config, and an order-preserving validator index loader. Minor: initial tests/requirements and a default output path.
