### PR TITLE
Expanded Validator Collection to 1–1000 and 40000–40400 - Dailylog

### DIFF
--- a/daily-logs/week4/25-08-25.md
+++ b/daily-logs/week4/25-08-25.md
@@ -1,0 +1,60 @@
+### Date & Topic
+
+- **Date:** 25th August, 2025
+- **Main Focus:** Collected validator data for indexes 1–1000 and 40000–40400 for ***Hybrid Dataset Construction for AI-Driven Validator Selection in Proof-of-Stake Blockchain Networks***
+
+---
+
+### 1. Search
+
+- **What did you look for?**
+
+  - Large index ranges for validators to expand the dataset
+  - Approaches to manage rate limits on beaconcha.in during bulk collection
+
+- **Where did you search?**
+
+  - Beaconcha.in API endpoints and docs
+  - CLI error logs from extended batch runs
+  - Collection scripts for indexing and batch handling
+
+---
+
+### 2. Investigate
+
+- **What did you dig into?**
+
+  - Ran collection commands for indexes 1–1000 and 40000–40400
+  - Validated data integrity and exported outputs in CSV/Parquet formats
+  - Monitored request patterns to confirm alignment with free-tier API limits
+  - Checked storage writes to ensure smooth appending of new validator ranges
+
+- **Any patterns or surprises?**
+
+  - Large continuous ranges work reliably with batching
+  - Some retry cycles triggered at higher loads, but data completeness preserved
+
+---
+
+### 3. Reflect
+
+- **What did you learn?**
+
+  - Extended ranges can be handled in one command but smaller batches are safer
+  - Workflow now scales to thousands of validators with minimal manual fixes
+
+- **What’s next?**
+
+  - Push collection beyond 40400 indexes
+  - Automate scripts for range-based collection to remove manual splitting
+
+---
+
+### 4. Actions
+
+- **Immediate actions:**
+
+  - Continue extending validator coverage with structured batches
+  - Add better logging for retries and request pacing
+
+---


### PR DESCRIPTION
Collected validator data for indexes 1–1000 and 40000–40400. Outputs validated in CSV/Parquet with stable batch execution. Minor tweaks done to keep request handling smooth and avoid file overwrites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a daily log for Aug 25, 2025 detailing validator data collection for indices 1–1000 and 40000–40400 within the hybrid dataset effort. Covers sources consulted, execution steps, batching behavior, retry patterns, validation/export outcomes, reflections on scalability, and next actions (extend coverage, automate range batching, improve logging/pacing). No UI or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->